### PR TITLE
fix: support umbrella chart naming and globals for studio charts

### DIFF
--- a/business-system-backend/helm/business-system-service/templates/_helpers.tpl
+++ b/business-system-backend/helm/business-system-service/templates/_helpers.tpl
@@ -27,10 +27,50 @@ app: {{ include "this-app.name" . }}
 
 
 {{- define "this-app.namespace" -}}
-{{- default .Release.Namespace .Values.namespace -}}
+{{- .Release.Namespace -}}
 {{- end -}}
 
 
 {{- define "this-app.image" -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry -}}
+{{- printf "%s/%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/* ========== Universal Global Values Merge Helpers ========== */}}
+
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $localDeps := .Values.depServices | default dict -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy $localDeps) $globalDeps) -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- index (.Values.depServices | default dict) "class-443" "ingressClass" | default "nginx" -}}
+{{- end -}}
 {{- end -}}

--- a/business-system-backend/helm/business-system-service/templates/configmap.yaml
+++ b/business-system-backend/helm/business-system-service/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata: 
@@ -6,19 +7,19 @@ metadata:
   labels:
     {{- include "this-app.labels" . | nindent 4 }}
 data: 
-  APP_DB_HOST: {{ .Values.depServices.rds.host | quote }}
-  APP_DB_PORT: {{ .Values.depServices.rds.port | quote }}
-  APP_DB_NAME: {{ .Values.depServices.rds.database | quote }}
-  APP_DB_USER: {{ .Values.depServices.rds.user | quote }}
-  APP_DB_PASSWORD: {{ .Values.depServices.rds.password | quote }}
-  APP_DB_TYPE: {{ .Values.depServices.rds.type | upper | quote }}
-  APP_DB_SYSTEMID: {{ .Values.depServices.rds.system_id | default "" | quote }}
+  APP_DB_HOST: {{ $depServices.rds.host | quote }}
+  APP_DB_PORT: {{ $depServices.rds.port | quote }}
+  APP_DB_NAME: {{ $depServices.rds.database | quote }}
+  APP_DB_USER: {{ $depServices.rds.user | quote }}
+  APP_DB_PASSWORD: {{ $depServices.rds.password | quote }}
+  APP_DB_TYPE: {{ $depServices.rds.type | upper | quote }}
+  APP_DB_SYSTEMID: {{ $depServices.rds.system_id | default "" | quote }}
 
-  APP_MQ_TYPE: {{ .Values.depServices.mq.mqType | quote }}
-  APP_MQ_HOST: {{ .Values.depServices.mq.mqHost | quote }}
-  APP_MQ_PORT: {{ .Values.depServices.mq.mqPort | quote }}
-  APP_MQ_LOOKUPD_HOST: {{ .Values.depServices.mq.mqLookupdHost | quote }}
-  APP_MQ_LOOKUPD_PORT: {{ .Values.depServices.mq.mqLookupdPort | quote }}
-  APP_MQ_AUTH_MECHANISM: {{ .Values.depServices.mq.auth.mechanism | quote }}
-  APP_MQ_AUTH_USERNAME: {{ .Values.depServices.mq.auth.username | quote }}
-  APP_MQ_AUTH_PASSWORD: {{ .Values.depServices.mq.auth.password | quote }}
+  APP_MQ_TYPE: {{ $depServices.mq.mqType | quote }}
+  APP_MQ_HOST: {{ $depServices.mq.mqHost | quote }}
+  APP_MQ_PORT: {{ $depServices.mq.mqPort | quote }}
+  APP_MQ_LOOKUPD_HOST: {{ $depServices.mq.mqLookupdHost | quote }}
+  APP_MQ_LOOKUPD_PORT: {{ $depServices.mq.mqLookupdPort | quote }}
+  APP_MQ_AUTH_MECHANISM: {{ $depServices.mq.auth.mechanism | quote }}
+  APP_MQ_AUTH_USERNAME: {{ $depServices.mq.auth.username | quote }}
+  APP_MQ_AUTH_PASSWORD: {{ $depServices.mq.auth.password | quote }}

--- a/business-system-backend/helm/business-system-service/templates/deployment.yaml
+++ b/business-system-backend/helm/business-system-service/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $replicaCount := include "mergedGlobalValues.replicaCount" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +7,7 @@ metadata:
   labels:
 {{ include "this-app.labels" . | indent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ $replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "this-app.name" . }}

--- a/business-system-backend/helm/business-system-service/templates/ingress.yaml
+++ b/business-system-backend/helm/business-system-service/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
+  ingressClassName: {{ include "mergedGlobalValues.ingressClassName" . }}
   rules:
   - http:
       paths:
@@ -32,7 +32,7 @@ metadata:
   name: {{ include "this-app.name" . }}
   namespace: {{ include "this-app.namespace" . }}
   annotations:
-    kubernetes.io/ingress.class: {{ index .Values.depServices "class-443" "ingressClass" }}
+    kubernetes.io/ingress.class: {{ include "mergedGlobalValues.ingressClassName" . }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -45,4 +45,3 @@ spec:
           servicePort: 80
         path: /api/business-system/v1
 {{- end }}
-

--- a/business-system-backend/helm/business-system-service/templates/initdb.yaml
+++ b/business-system-backend/helm/business-system-service/templates/initdb.yaml
@@ -1,3 +1,4 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata: 
@@ -10,13 +11,13 @@ metadata:
     helm.sh/hook: "post-install, post-upgrade"
     helm.sh/weight: "0"
 data: 
-  APP_DB_HOST: {{ .Values.depServices.rds.host | quote }}
-  APP_DB_PORT: {{ .Values.depServices.rds.port | quote }}
-  APP_DB_NAME: {{ .Values.depServices.rds.database | quote }}
-  APP_DB_USER: {{ .Values.depServices.rds.user | quote }}
-  APP_DB_PASSWORD: {{ .Values.depServices.rds.password | quote }}
-  APP_DB_TYPE: {{ .Values.depServices.rds.type | upper | quote }}
-  APP_DB_SYSTEMID: {{ .Values.depServices.rds.system_id | default "" | quote }}
+  APP_DB_HOST: {{ $depServices.rds.host | quote }}
+  APP_DB_PORT: {{ $depServices.rds.port | quote }}
+  APP_DB_NAME: {{ $depServices.rds.database | quote }}
+  APP_DB_USER: {{ $depServices.rds.user | quote }}
+  APP_DB_PASSWORD: {{ $depServices.rds.password | quote }}
+  APP_DB_TYPE: {{ $depServices.rds.type | upper | quote }}
+  APP_DB_SYSTEMID: {{ $depServices.rds.system_id | default "" | quote }}
 
 
 ---

--- a/deploy-web/charts/deploy-web/templates/configmap.yaml
+++ b/deploy-web/charts/deploy-web/templates/configmap.yaml
@@ -1,14 +1,15 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $accessAddress := include "mergedGlobalValues.accessAddress" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata: 
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
 data: 
   depServices.yaml: |
-    {{- toYaml .Values.depServices |  nindent 4 }}
+    {{- toYaml $depServices |  nindent 4 }}
   accessAddr.yaml: |
-    {{- toYaml .Values.accessAddress |  nindent 4 }}
-
+    {{- toYaml $accessAddress |  nindent 4 }}
 

--- a/deploy-web/charts/deploy-web/templates/deployment.yaml
+++ b/deploy-web/charts/deploy-web/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- $replicaCount := include "mergedGlobalValues.replicaCount" . | int -}}
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: apps/v1
 {{- else -}}
@@ -6,7 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
 spec:
@@ -15,9 +18,9 @@ spec:
   {{- toYaml . | nindent 4 }}
   {{- end }}
   {{ if not .Values.maxReplicaCount}}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ $replicaCount }}
   {{- else }}
-  replicas: {{ min .Values.replicaCount .Values.maxReplicaCount }}
+  replicas: {{ min $replicaCount .Values.maxReplicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -50,7 +53,7 @@ spec:
         - name: deploy-web-service
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.deploy_web_service.repository }}:{{ .Values.image.deploy_web_service.tag }}"
+          image: "{{ $imageRegistry }}/{{ .Values.image.deploy_web_service.repository }}:{{ .Values.image.deploy_web_service.tag }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: 5
@@ -98,7 +101,7 @@ spec:
         - name: deploy-web-static
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.deploy_web_static.repository }}:{{ .Values.image.deploy_web_static.tag }}"
+          image: "{{ $imageRegistry }}/{{ .Values.image.deploy_web_static.repository }}:{{ .Values.image.deploy_web_static.tag }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: 5

--- a/deploy-web/charts/deploy-web/templates/helpers.tpl
+++ b/deploy-web/charts/deploy-web/templates/helpers.tpl
@@ -2,24 +2,18 @@
 Expand the name of the chart.
 */}}
 {{- define "template.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "template.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Release.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -67,3 +61,44 @@ Inject label for user
 {{- define "template.injectLabels" -}}
 {{- toYaml .Values.labels }}
 {{- end }}
+
+{{/* ========== Universal Global Values Merge Helpers ========== */}}
+
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $localDeps := .Values.depServices | default dict -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy $localDeps) $globalDeps) -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.accessAddress" -}}
+{{- $localAccess := .Values.accessAddress | default dict -}}
+{{- $globalAccess := (.Values.global | default dict).accessAddress | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy $localAccess) $globalAccess) -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- index (.Values.depServices | default dict) "class-443" "ingressClass" | default "nginx" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy-web/charts/deploy-web/templates/ingress.yaml
+++ b/deploy-web/charts/deploy-web/templates/ingress.yaml
@@ -1,16 +1,17 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
+  ingressClassName: {{ include "mergedGlobalValues.ingressClassName" . }}
   rules:
   - http:
       paths:
@@ -51,9 +52,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: {{ index .Values.depServices "class-443" "ingressClass" }}
+    kubernetes.io/ingress.class: {{ include "mergedGlobalValues.ingressClassName" . }}
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -79,4 +80,3 @@ spec:
         path: /deploy
       
 {{- end }}
-

--- a/deploy-web/charts/deploy-web/templates/service.yaml
+++ b/deploy-web/charts/deploy-web/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ $.Values.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   name: {{ include "template.fullname" $ }}-static
   labels:
     {{- include "template.labels" $ | nindent 4 }}
@@ -25,7 +25,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ $.Values.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   name: {{ include "template.fullname" $ }}-service
   labels:
     {{- include "template.labels" $ | nindent 4 }}
@@ -48,4 +48,3 @@ spec:
     name: app
   selector:
     {{- include "template.selectorLabels" $ | nindent 4 }}
-

--- a/deploy-web/charts/deploy-web/templates/serviceaccount.yaml
+++ b/deploy-web/charts/deploy-web/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ include "template.serviceAccountName" . }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "template.serviceAccountName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,13 +23,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "template.serviceAccountName" . }}
-    namespace: {{ .Values.namespace | default .Release.Namespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "template.serviceAccountName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - "*"

--- a/frontend/applications/business-system/charts/business-system/templates/_helpers.tpl
+++ b/frontend/applications/business-system/charts/business-system/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- "class-443" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.image" -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry -}}
+{{- printf "%s%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" (.Values.image.repository | trimPrefix "/") .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/frontend/applications/business-system/charts/business-system/templates/deployment.yaml
+++ b/frontend/applications/business-system/charts/business-system/templates/deployment.yaml
@@ -1,10 +1,11 @@
+{{- $image := include "mergedGlobalValues.image" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}
@@ -25,7 +26,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ $image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: {{ .Values.service.ports.http }}

--- a/frontend/applications/business-system/charts/business-system/templates/ingress.yaml
+++ b/frontend/applications/business-system/charts/business-system/templates/ingress.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-business-system-frontend
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     nginx.ingress.kubernetes.io/limit-rps: "{{ .Values.ingress.rps.limit }}" # rps：每秒多少请求 超过之后就报错 https status: 503
 spec:
-  ingressClassName: class-443
+  ingressClassName: {{ include "mergedGlobalValues.ingressClassName" . }}
   rules:
     - http:
         paths:

--- a/frontend/applications/business-system/charts/business-system/templates/service.yaml
+++ b/frontend/applications/business-system/charts/business-system/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.service.enableDualStack }}
   ipFamilyPolicy: PreferDualStack

--- a/frontend/applications/model-manager/charts/model-manager/templates/_helpers.tpl
+++ b/frontend/applications/model-manager/charts/model-manager/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- define "mfModelManagerNginx.imageRegistry" -}}
 {{- $globalImage := (.Values.global | default dict).image | default dict -}}
 {{- if $globalImage.registry -}}
 {{- $globalImage.registry -}}
@@ -7,7 +7,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.replicaCount" -}}
+{{- define "mfModelManagerNginx.replicaCount" -}}
 {{- $global := .Values.global | default dict -}}
 {{- if hasKey $global "replicaCount" -}}
 {{- $global.replicaCount -}}
@@ -16,7 +16,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- define "mfModelManagerNginx.ingressClassName" -}}
 {{- $global := .Values.global | default dict -}}
 {{- if hasKey $global "ingressClassName" -}}
 {{- $global.ingressClassName -}}
@@ -25,11 +25,12 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.image" -}}
-{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- define "mfModelManagerNginx.image" -}}
+{{- $imageRegistry := include "mfModelManagerNginx.imageRegistry" . | trimSuffix "/" -}}
+{{- $repository := .Values.image.repository | trimPrefix "/" -}}
 {{- if $imageRegistry -}}
-{{- printf "%s%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- printf "%s/%s:%s" $imageRegistry $repository .Values.image.tag -}}
 {{- else -}}
-{{- printf "%s:%s" (.Values.image.repository | trimPrefix "/") .Values.image.tag -}}
+{{- printf "%s:%s" $repository .Values.image.tag -}}
 {{- end -}}
 {{- end -}}

--- a/frontend/applications/model-manager/charts/model-manager/templates/_helpers.tpl
+++ b/frontend/applications/model-manager/charts/model-manager/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- "class-443" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.image" -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry -}}
+{{- printf "%s%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" (.Values.image.repository | trimPrefix "/") .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/frontend/applications/model-manager/charts/model-manager/templates/deployment.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/deployment.yaml
@@ -1,10 +1,11 @@
+{{- $image := include "mergedGlobalValues.image" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}
@@ -25,7 +26,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ $image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: {{ .Values.service.ports.http }}

--- a/frontend/applications/model-manager/charts/model-manager/templates/deployment.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/deployment.yaml
@@ -1,11 +1,11 @@
-{{- $image := include "mergedGlobalValues.image" . -}}
+{{- $image := include "mfModelManagerNginx.image" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.image.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
+  replicas: {{ include "mfModelManagerNginx.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}

--- a/frontend/applications/model-manager/charts/model-manager/templates/ingress.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/ingress.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-model-manager-web
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     nginx.ingress.kubernetes.io/limit-rps: "{{ .Values.ingress.rps.limit }}" # rps：每秒多少请求 超过之后就报错 https status: 503
 spec:
-  ingressClassName: class-443
+  ingressClassName: {{ include "mergedGlobalValues.ingressClassName" . }}
   rules:
     - http:
         paths:

--- a/frontend/applications/model-manager/charts/model-manager/templates/ingress.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/limit-rps: "{{ .Values.ingress.rps.limit }}" # rps：每秒多少请求 超过之后就报错 https status: 503
 spec:
-  ingressClassName: {{ include "mergedGlobalValues.ingressClassName" . }}
+  ingressClassName: {{ include "mfModelManagerNginx.ingressClassName" . }}
   rules:
     - http:
         paths:

--- a/frontend/applications/model-manager/charts/model-manager/templates/post-delete-job.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/post-delete-job.yaml
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-delete-job
-          image: "{{ include "mergedGlobalValues.image" . }}"
+          image: "{{ include "mfModelManagerNginx.image" . }}"
           command:
             - "sh"
             - "-c"

--- a/frontend/applications/model-manager/charts/model-manager/templates/post-delete-job.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/post-delete-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-post-delete-job
+  name: {{ .Values.image.name }}-post-delete-job
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}
+      name: {{ .Values.image.name }}-post-delete
       labels:
         release: {{ .Release.Name }}
         chart: {{ .Chart.Name }}
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-delete-job
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "mergedGlobalValues.image" . }}"
           command:
             - "sh"
             - "-c"

--- a/frontend/applications/model-manager/charts/model-manager/templates/post-install-job.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/post-install-job.yaml
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
-          image: "{{ include "mergedGlobalValues.image" . }}"
+          image: "{{ include "mfModelManagerNginx.image" . }}"
           command:
             - "sh"
             - "-c"

--- a/frontend/applications/model-manager/charts/model-manager/templates/post-install-job.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/post-install-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-post-install-job
+  name: {{ .Values.image.name }}-post-install-job
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}
+      name: {{ .Values.image.name }}-post-install
       labels:
         release: {{ .Release.Name }}
         chart: {{ .Chart.Name }}
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "mergedGlobalValues.image" . }}"
           command:
             - "sh"
             - "-c"

--- a/frontend/applications/model-manager/charts/model-manager/templates/service.yaml
+++ b/frontend/applications/model-manager/charts/model-manager/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.service.enableDualStack }}
   ipFamilyPolicy: PreferDualStack

--- a/mf-model-api/charts/templates/_helpers.tpl
+++ b/mf-model-api/charts/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $localDeps := .Values.depServices | default dict -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy $localDeps) $globalDeps) -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.image" -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry -}}
+{{- printf "%s%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" (.Values.image.repository | trimPrefix "/") .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/mf-model-api/charts/templates/_helpers.tpl
+++ b/mf-model-api/charts/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- define "mfModelApi.imageRegistry" -}}
 {{- $globalImage := (.Values.global | default dict).image | default dict -}}
 {{- if $globalImage.registry -}}
 {{- $globalImage.registry -}}
@@ -7,7 +7,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.replicaCount" -}}
+{{- define "mfModelApi.replicaCount" -}}
 {{- $global := .Values.global | default dict -}}
 {{- if hasKey $global "replicaCount" -}}
 {{- $global.replicaCount -}}
@@ -16,17 +16,18 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.depServices" -}}
+{{- define "mfModelApi.depServices" -}}
 {{- $localDeps := .Values.depServices | default dict -}}
 {{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
 {{- toYaml (mergeOverwrite (deepCopy $localDeps) $globalDeps) -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.image" -}}
-{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- define "mfModelApi.image" -}}
+{{- $imageRegistry := include "mfModelApi.imageRegistry" . | trimSuffix "/" -}}
+{{- $repository := .Values.image.repository | trimPrefix "/" -}}
 {{- if $imageRegistry -}}
-{{- printf "%s%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- printf "%s/%s:%s" $imageRegistry $repository .Values.image.tag -}}
 {{- else -}}
-{{- printf "%s:%s" (.Values.image.repository | trimPrefix "/") .Values.image.tag -}}
+{{- printf "%s:%s" $repository .Values.image.tag -}}
 {{- end -}}
 {{- end -}}

--- a/mf-model-api/charts/templates/configmap.yaml
+++ b/mf-model-api/charts/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $depServices := include "mfModelApi.depServices" . | fromYaml -}}
 apiVersion: v1
 data:
   RDSHOST: {{ $depServices.rds.host | quote }}

--- a/mf-model-api/charts/templates/configmap.yaml
+++ b/mf-model-api/charts/templates/configmap.yaml
@@ -1,59 +1,60 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: v1
 data:
-  RDSHOST: {{ .Values.depServices.rds.host | quote }}
-  RDSPORT: {{ quote .Values.depServices.rds.port }}
-  RDSUSER: {{ .Values.depServices.rds.user }}
-  RDSPASS: {{ .Values.depServices.rds.password }}
-  DB_TYPE: {{ .Values.depServices.rds.type | quote}}
-  RDSDBNAME: {{ .Values.depServices.rds.database | quote }}
-  OPENSEARCH_HOST: {{ .Values.depServices.opensearch.host | quote}}
-  OPENSEARCHRED: {{ .Values.depServices.opensearch.read | quote}}
-  OPENSEARCHWRITE: {{ .Values.depServices.opensearch.write | quote}}
-  OPENSEARCH_PORT: {{ quote .Values.depServices.opensearch.port }}
-  OPENSEARCH_USER: {{ .Values.depServices.opensearch.user | quote}}
-  OPENSEARCH_PASS: {{ .Values.depServices.opensearch.password | quote}}
-  REDISCLUSTERMODE: {{ .Values.depServices.redis.connectType | quote}}
-  REDISUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
-  {{- if eq .Values.depServices.redis.connectType "sentinel" }}
-  REDISHOST: {{ quote .Values.depServices.redis.connectInfo.sentinelHost }}
-  REDISPORT: {{ quote .Values.depServices.redis.connectInfo.sentinelPort }}
-  SENTINELMASTER: {{ .Values.depServices.redis.connectInfo.masterGroupName | quote }}
-  SENTINELUSER: {{ .Values.depServices.redis.connectInfo.sentinelUsername | quote}}
-  SENTINELPASS: {{ .Values.depServices.redis.connectInfo.sentinelPassword | quote}}
-  {{- else if eq .Values.depServices.redis.connectType "standalone" }}
-  REDISHOST: {{ quote .Values.depServices.redis.connectInfo.host }}
-  REDISPORT: {{ quote .Values.depServices.redis.connectInfo.port }}
-  {{- else if eq .Values.depServices.redis.connectType "master-slave" }}
-  REDISREADHOST: {{ .Values.depServices.redis.connectInfo.slaveHost | quote}}
-  REDISREADPORT: {{ quote .Values.depServices.redis.connectInfo.slavePort }}
-  REDISREADUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISREADPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
-  REDISWRITEHOST: {{ .Values.depServices.redis.connectInfo.masterHost | quote}}
-  REDISWRITEPORT: {{ quote .Values.depServices.redis.connectInfo.masterPort }}
-  REDISWRITEUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISWRITEPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
+  RDSHOST: {{ $depServices.rds.host | quote }}
+  RDSPORT: {{ quote $depServices.rds.port }}
+  RDSUSER: {{ $depServices.rds.user }}
+  RDSPASS: {{ $depServices.rds.password }}
+  DB_TYPE: {{ $depServices.rds.type | quote}}
+  RDSDBNAME: {{ $depServices.rds.database | quote }}
+  OPENSEARCH_HOST: {{ $depServices.opensearch.host | quote}}
+  OPENSEARCHRED: {{ $depServices.opensearch.read | quote}}
+  OPENSEARCHWRITE: {{ $depServices.opensearch.write | quote}}
+  OPENSEARCH_PORT: {{ quote $depServices.opensearch.port }}
+  OPENSEARCH_USER: {{ $depServices.opensearch.user | quote}}
+  OPENSEARCH_PASS: {{ $depServices.opensearch.password | quote}}
+  REDISCLUSTERMODE: {{ $depServices.redis.connectType | quote}}
+  REDISUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISPASS: {{ $depServices.redis.connectInfo.password | quote}}
+  {{- if eq $depServices.redis.connectType "sentinel" }}
+  REDISHOST: {{ quote $depServices.redis.connectInfo.sentinelHost }}
+  REDISPORT: {{ quote $depServices.redis.connectInfo.sentinelPort }}
+  SENTINELMASTER: {{ $depServices.redis.connectInfo.masterGroupName | quote }}
+  SENTINELUSER: {{ $depServices.redis.connectInfo.sentinelUsername | quote}}
+  SENTINELPASS: {{ $depServices.redis.connectInfo.sentinelPassword | quote}}
+  {{- else if eq $depServices.redis.connectType "standalone" }}
+  REDISHOST: {{ quote $depServices.redis.connectInfo.host }}
+  REDISPORT: {{ quote $depServices.redis.connectInfo.port }}
+  {{- else if eq $depServices.redis.connectType "master-slave" }}
+  REDISREADHOST: {{ $depServices.redis.connectInfo.slaveHost | quote}}
+  REDISREADPORT: {{ quote $depServices.redis.connectInfo.slavePort }}
+  REDISREADUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISREADPASS: {{ $depServices.redis.connectInfo.password | quote}}
+  REDISWRITEHOST: {{ $depServices.redis.connectInfo.masterHost | quote}}
+  REDISWRITEPORT: {{ quote $depServices.redis.connectInfo.masterPort }}
+  REDISWRITEUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISWRITEPASS: {{ $depServices.redis.connectInfo.password | quote}}
   {{- end }}
-  KAFKAHOST: {{ .Values.depServices.mq.mqHost | quote }}
-  KAFKAPORT: {{ quote .Values.depServices.mq.mqPort }}
-  KAFKAUSER: {{ .Values.depServices.mq.auth.username | quote }}
-  KAFKAPASS: {{ .Values.depServices.mq.auth.password | quote }}
-  TEXTVECTORMAPPING: {{ quote .Values.depServices.text_vector.mapping | quote }}
-  VLMVECTORMAPPING: {{ quote .Values.depServices.text_vector.mapping | quote }}
-  TEXTRERANKERMAPPING: {{ quote .Values.depServices.text_reranker.mapping | quote }}
+  KAFKAHOST: {{ $depServices.mq.mqHost | quote }}
+  KAFKAPORT: {{ quote $depServices.mq.mqPort }}
+  KAFKAUSER: {{ $depServices.mq.auth.username | quote }}
+  KAFKAPASS: {{ $depServices.mq.auth.password | quote }}
+  TEXTVECTORMAPPING: {{ quote $depServices.text_vector.mapping | quote }}
+  VLMVECTORMAPPING: {{ quote $depServices.text_vector.mapping | quote }}
+  TEXTRERANKERMAPPING: {{ quote $depServices.text_reranker.mapping | quote }}
   # 授权服务
-  OAUTHPUBLICHOST: {{ .Values.depServices.hydra.publicHost | quote }}
-  OAUTHPUBLICPORT: {{ .Values.depServices.hydra.publicPort | quote }}
-  OAUTHADMINHOST: {{ .Values.depServices.hydra.administrativeHost | quote }}
-  OAUTHADMINPORT: {{ .Values.depServices.hydra.administrativePort | quote }}
+  OAUTHPUBLICHOST: {{ $depServices.hydra.publicHost | quote }}
+  OAUTHPUBLICPORT: {{ $depServices.hydra.publicPort | quote }}
+  OAUTHADMINHOST: {{ $depServices.hydra.administrativeHost | quote }}
+  OAUTHADMINPORT: {{ $depServices.hydra.administrativePort | quote }}
   # user-management服务
-  USERMANAGEMENTPUBLICHOST: {{ .Values.depServices.user_management.publicHost | quote }}
-  USERMANAGEMENTPUBLICPORT: {{ .Values.depServices.user_management.publicPort | quote }}
-  USERMANAGEMENTPRIVATEHOST: {{ .Values.depServices.user_management.privateHost | quote }}
-  USERMANAGEMENTPRIVATEPORT: {{ .Values.depServices.user_management.privatePort | quote }}
+  USERMANAGEMENTPUBLICHOST: {{ $depServices.user_management.publicHost | quote }}
+  USERMANAGEMENTPUBLICPORT: {{ $depServices.user_management.publicPort | quote }}
+  USERMANAGEMENTPRIVATEHOST: {{ $depServices.user_management.privateHost | quote }}
+  USERMANAGEMENTPRIVATEPORT: {{ $depServices.user_management.privatePort | quote }}
   # authorization服务
-  AUTHORIZATIONPRIVATEHOST: {{ .Values.depServices.authorization.privateHost | quote }}
-  AUTHORIZATIONPRIVATEPORT: {{ .Values.depServices.authorization.privatePort | quote }}
+  AUTHORIZATIONPRIVATEHOST: {{ $depServices.authorization.privateHost | quote }}
+  AUTHORIZATIONPRIVATEPORT: {{ $depServices.authorization.privatePort | quote }}
   dm_svc.conf: |
     TIME_ZON=(480)
     LANGUAGE=(cn)
@@ -63,5 +64,5 @@ data:
 
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-yaml
-  namespace: {{ .Values.namespace }}
+  name: {{ .Values.image.name }}-yaml
+  namespace: {{ .Release.Namespace }}

--- a/mf-model-api/charts/templates/deployment.yaml
+++ b/mf-model-api/charts/templates/deployment.yaml
@@ -1,10 +1,13 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $configMapName := printf "%s-yaml" .Values.image.name -}}
+{{- $rdsConfVolume := printf "%s-rds-conf" .Values.image.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}
@@ -32,7 +35,7 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "mergedGlobalValues.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: model-factory
@@ -58,7 +61,7 @@ spec:
           volumeMounts:
             - name: host-time
               mountPath: /etc/localtime
-            - name: {{ .Release.Name }}-rds-conf
+            - name: {{ $rdsConfVolume }}
               mountPath: /tmp/rds_conf
           env:
             - name: DEVICE_CODE
@@ -66,236 +69,236 @@ spec:
             - name: RDSHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSHOST
             - name: RDSPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSPORT
             - name: RDSUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSUSER
             - name: RDSPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSPASS
             - name: DB_TYPE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: DB_TYPE
             - name: RDSDBNAME
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSDBNAME
             - name: OPENSEARCH_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_HOST
             - name: OPENSEARCHWRITE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCHWRITE
             - name: OPENSEARCHREAD
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCHRED
             - name: OPENSEARCH_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_PORT
             - name: OPENSEARCH_USER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_USER
             - name: OPENSEARCH_PASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_PASS
             - name: REDISCLUSTERMODE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISCLUSTERMODE
             - name: REDISUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISUSER
             - name: REDISPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISPASS
-            {{- if ne .Values.depServices.redis.connectType "master-slave" }}
+            {{- if ne $depServices.redis.connectType "master-slave" }}
             - name: REDISHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISHOST
             - name: REDISPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISPORT
             {{- end }}
-            {{- if eq .Values.depServices.redis.connectType "sentinel" }}
+            {{- if eq $depServices.redis.connectType "sentinel" }}
             - name: SENTINELMASTER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: SENTINELMASTER
             - name: SENTINELUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: SENTINELUSER
             - name: SENTINELPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: SENTINELPASS
             {{- end }}
-            {{- if eq .Values.depServices.redis.connectType "master-slave" }}
+            {{- if eq $depServices.redis.connectType "master-slave" }}
             - name: REDISREADHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADHOST
             - name: REDISREADPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADPORT
             - name: REDISREADUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADUSER
             - name: REDISREADPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADPASS
             - name: REDISWRITEHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEHOST
             - name: REDISWRITEPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEPORT
             - name: REDISWRITEUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEUSER
             - name: REDISWRITEPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEPASS
             {{- end }}
             - name: KAFKAHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAHOST
             - name: KAFKAPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAPORT
             - name: KAFKAUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAUSER
             - name: KAFKAPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAPASS
             # 修复以下三个环境变量的配置
             - name: TEXTVECTORMAPPING
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: TEXTVECTORMAPPING
             - name: VLMVECTORMAPPING
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: VLMVECTORMAPPING
             - name: TEXTRERANKERMAPPING
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: TEXTRERANKERMAPPING
             - name: DM_SVC_PATH
               value: /tmp/rds_conf/
             - name: OAUTHPUBLICHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHPUBLICHOST
             - name: OAUTHPUBLICPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHPUBLICPORT
             - name: OAUTHADMINHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHADMINHOST
             - name: OAUTHADMINPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHADMINPORT
             - name: USERMANAGEMENTPUBLICHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPUBLICHOST
             - name: USERMANAGEMENTPUBLICPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPUBLICPORT
             - name: USERMANAGEMENTPRIVATEHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPRIVATEHOST
             - name: USERMANAGEMENTPRIVATEPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPRIVATEPORT
             - name: AUTHORIZATIONPRIVATEHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: AUTHORIZATIONPRIVATEHOST
             - name: AUTHORIZATIONPRIVATEPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: AUTHORIZATIONPRIVATEPORT
             # 可观测相关配置
             - name: LOG_ENABLED
@@ -332,9 +335,9 @@ spec:
         - name: host-time
           hostPath:
             path: /etc/localtime
-        - name: {{ .Release.Name }}-rds-conf
+        - name: {{ $rdsConfVolume }}
           configMap:
-            name: {{ .Release.Name }}-yaml
+            name: {{ $configMapName }}
             items:
             - key: dm_svc.conf
               path: dm_svc.conf

--- a/mf-model-api/charts/templates/deployment.yaml
+++ b/mf-model-api/charts/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $depServices := include "mfModelApi.depServices" . | fromYaml -}}
 {{- $configMapName := printf "%s-yaml" .Values.image.name -}}
 {{- $rdsConfVolume := printf "%s-rds-conf" .Values.image.name -}}
 apiVersion: apps/v1
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.image.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
+  replicas: {{ include "mfModelApi.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}
@@ -35,7 +35,7 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
-          image: "{{ include "mergedGlobalValues.image" . }}"
+          image: "{{ include "mfModelApi.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: model-factory

--- a/mf-model-api/charts/templates/service.yaml
+++ b/mf-model-api/charts/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.service.enableDualStack }}
   ipFamilyPolicy: PreferDualStack

--- a/mf-model-manager/charts/templates/_helpers.tpl
+++ b/mf-model-manager/charts/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $localDeps := .Values.depServices | default dict -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy $localDeps) $globalDeps) -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.image" -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry -}}
+{{- printf "%s%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" (.Values.image.repository | trimPrefix "/") .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/mf-model-manager/charts/templates/_helpers.tpl
+++ b/mf-model-manager/charts/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- define "mfModelManager.imageRegistry" -}}
 {{- $globalImage := (.Values.global | default dict).image | default dict -}}
 {{- if $globalImage.registry -}}
 {{- $globalImage.registry -}}
@@ -7,7 +7,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.replicaCount" -}}
+{{- define "mfModelManager.replicaCount" -}}
 {{- $global := .Values.global | default dict -}}
 {{- if hasKey $global "replicaCount" -}}
 {{- $global.replicaCount -}}
@@ -16,17 +16,18 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.depServices" -}}
+{{- define "mfModelManager.depServices" -}}
 {{- $localDeps := .Values.depServices | default dict -}}
 {{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
 {{- toYaml (mergeOverwrite (deepCopy $localDeps) $globalDeps) -}}
 {{- end -}}
 
-{{- define "mergedGlobalValues.image" -}}
-{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- define "mfModelManager.image" -}}
+{{- $imageRegistry := include "mfModelManager.imageRegistry" . | trimSuffix "/" -}}
+{{- $repository := .Values.image.repository | trimPrefix "/" -}}
 {{- if $imageRegistry -}}
-{{- printf "%s%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- printf "%s/%s:%s" $imageRegistry $repository .Values.image.tag -}}
 {{- else -}}
-{{- printf "%s:%s" (.Values.image.repository | trimPrefix "/") .Values.image.tag -}}
+{{- printf "%s:%s" $repository .Values.image.tag -}}
 {{- end -}}
 {{- end -}}

--- a/mf-model-manager/charts/templates/configmap.yaml
+++ b/mf-model-manager/charts/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $depServices := include "mfModelManager.depServices" . | fromYaml -}}
 apiVersion: v1
 data:
   RDSHOST: {{ $depServices.rds.host | quote }}

--- a/mf-model-manager/charts/templates/configmap.yaml
+++ b/mf-model-manager/charts/templates/configmap.yaml
@@ -1,59 +1,60 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: v1
 data:
-  RDSHOST: {{ .Values.depServices.rds.host | quote }}
-  RDSPORT: {{ quote .Values.depServices.rds.port }}
-  RDSUSER: {{ .Values.depServices.rds.user }}
-  RDSPASS: {{ .Values.depServices.rds.password }}
-  DB_TYPE: {{ .Values.depServices.rds.type | quote}}
-  RDSDBNAME: {{ .Values.depServices.rds.database | quote }}
-  OPENSEARCH_HOST: {{ .Values.depServices.opensearch.host | quote}}
-  OPENSEARCHRED: {{ .Values.depServices.opensearch.read | quote}}
-  OPENSEARCHWRITE: {{ .Values.depServices.opensearch.write | quote}}
-  OPENSEARCH_PORT: {{ quote .Values.depServices.opensearch.port }}
-  OPENSEARCH_USER: {{ .Values.depServices.opensearch.user | quote}}
-  OPENSEARCH_PASS: {{ .Values.depServices.opensearch.password | quote}}
-  REDISCLUSTERMODE: {{ .Values.depServices.redis.connectType | quote}}
-  REDISUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
-  {{- if eq .Values.depServices.redis.connectType "sentinel" }}
-  REDISHOST: {{ quote .Values.depServices.redis.connectInfo.sentinelHost }}
-  REDISPORT: {{ quote .Values.depServices.redis.connectInfo.sentinelPort }}
-  SENTINELMASTER: {{ .Values.depServices.redis.connectInfo.masterGroupName | quote }}
-  SENTINELUSER: {{ .Values.depServices.redis.connectInfo.sentinelUsername | quote}}
-  SENTINELPASS: {{ .Values.depServices.redis.connectInfo.sentinelPassword | quote}}
-  {{- else if eq .Values.depServices.redis.connectType "standalone" }}
-  REDISHOST: {{ quote .Values.depServices.redis.connectInfo.host }}
-  REDISPORT: {{ quote .Values.depServices.redis.connectInfo.port }}
-  {{- else if eq .Values.depServices.redis.connectType "master-slave" }}
-  REDISREADHOST: {{ .Values.depServices.redis.connectInfo.slaveHost | quote}}
-  REDISREADPORT: {{ quote .Values.depServices.redis.connectInfo.slavePort }}
-  REDISREADUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISREADPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
-  REDISWRITEHOST: {{ .Values.depServices.redis.connectInfo.masterHost | quote}}
-  REDISWRITEPORT: {{ quote .Values.depServices.redis.connectInfo.masterPort }}
-  REDISWRITEUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISWRITEPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
+  RDSHOST: {{ $depServices.rds.host | quote }}
+  RDSPORT: {{ quote $depServices.rds.port }}
+  RDSUSER: {{ $depServices.rds.user }}
+  RDSPASS: {{ $depServices.rds.password }}
+  DB_TYPE: {{ $depServices.rds.type | quote}}
+  RDSDBNAME: {{ $depServices.rds.database | quote }}
+  OPENSEARCH_HOST: {{ $depServices.opensearch.host | quote}}
+  OPENSEARCHRED: {{ $depServices.opensearch.read | quote}}
+  OPENSEARCHWRITE: {{ $depServices.opensearch.write | quote}}
+  OPENSEARCH_PORT: {{ quote $depServices.opensearch.port }}
+  OPENSEARCH_USER: {{ $depServices.opensearch.user | quote}}
+  OPENSEARCH_PASS: {{ $depServices.opensearch.password | quote}}
+  REDISCLUSTERMODE: {{ $depServices.redis.connectType | quote}}
+  REDISUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISPASS: {{ $depServices.redis.connectInfo.password | quote}}
+  {{- if eq $depServices.redis.connectType "sentinel" }}
+  REDISHOST: {{ quote $depServices.redis.connectInfo.sentinelHost }}
+  REDISPORT: {{ quote $depServices.redis.connectInfo.sentinelPort }}
+  SENTINELMASTER: {{ $depServices.redis.connectInfo.masterGroupName | quote }}
+  SENTINELUSER: {{ $depServices.redis.connectInfo.sentinelUsername | quote}}
+  SENTINELPASS: {{ $depServices.redis.connectInfo.sentinelPassword | quote}}
+  {{- else if eq $depServices.redis.connectType "standalone" }}
+  REDISHOST: {{ quote $depServices.redis.connectInfo.host }}
+  REDISPORT: {{ quote $depServices.redis.connectInfo.port }}
+  {{- else if eq $depServices.redis.connectType "master-slave" }}
+  REDISREADHOST: {{ $depServices.redis.connectInfo.slaveHost | quote}}
+  REDISREADPORT: {{ quote $depServices.redis.connectInfo.slavePort }}
+  REDISREADUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISREADPASS: {{ $depServices.redis.connectInfo.password | quote}}
+  REDISWRITEHOST: {{ $depServices.redis.connectInfo.masterHost | quote}}
+  REDISWRITEPORT: {{ quote $depServices.redis.connectInfo.masterPort }}
+  REDISWRITEUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISWRITEPASS: {{ $depServices.redis.connectInfo.password | quote}}
   {{- end }}
-  KAFKAHOST: {{ .Values.depServices.mq.mqHost | quote }}
-  KAFKAPORT: {{ quote .Values.depServices.mq.mqPort }}
-  KAFKAUSER: {{ .Values.depServices.mq.auth.username | quote }}
-  KAFKAPASS: {{ .Values.depServices.mq.auth.password | quote }}
-  TEXTVECTORMAPPING: {{ quote .Values.depServices.text_vector.mapping | quote }}
-  VLMVECTORMAPPING: {{ quote .Values.depServices.text_vector.mapping | quote }}
-  TEXTRERANKERMAPPING: {{ quote .Values.depServices.text_reranker.mapping | quote }}
+  KAFKAHOST: {{ $depServices.mq.mqHost | quote }}
+  KAFKAPORT: {{ quote $depServices.mq.mqPort }}
+  KAFKAUSER: {{ $depServices.mq.auth.username | quote }}
+  KAFKAPASS: {{ $depServices.mq.auth.password | quote }}
+  TEXTVECTORMAPPING: {{ quote $depServices.text_vector.mapping | quote }}
+  VLMVECTORMAPPING: {{ quote $depServices.text_vector.mapping | quote }}
+  TEXTRERANKERMAPPING: {{ quote $depServices.text_reranker.mapping | quote }}
   # 授权服务
-  OAUTHPUBLICHOST: {{ .Values.depServices.hydra.publicHost | quote }}
-  OAUTHPUBLICPORT: {{ .Values.depServices.hydra.publicPort | quote }}
-  OAUTHADMINHOST: {{ .Values.depServices.hydra.administrativeHost | quote }}
-  OAUTHADMINPORT: {{ .Values.depServices.hydra.administrativePort | quote }}
+  OAUTHPUBLICHOST: {{ $depServices.hydra.publicHost | quote }}
+  OAUTHPUBLICPORT: {{ $depServices.hydra.publicPort | quote }}
+  OAUTHADMINHOST: {{ $depServices.hydra.administrativeHost | quote }}
+  OAUTHADMINPORT: {{ $depServices.hydra.administrativePort | quote }}
   # user-management服务
-  USERMANAGEMENTPUBLICHOST: {{ .Values.depServices.user_management.publicHost | quote }}
-  USERMANAGEMENTPUBLICPORT: {{ .Values.depServices.user_management.publicPort | quote }}
-  USERMANAGEMENTPRIVATEHOST: {{ .Values.depServices.user_management.privateHost | quote }}
-  USERMANAGEMENTPRIVATEPORT: {{ .Values.depServices.user_management.privatePort | quote }}
+  USERMANAGEMENTPUBLICHOST: {{ $depServices.user_management.publicHost | quote }}
+  USERMANAGEMENTPUBLICPORT: {{ $depServices.user_management.publicPort | quote }}
+  USERMANAGEMENTPRIVATEHOST: {{ $depServices.user_management.privateHost | quote }}
+  USERMANAGEMENTPRIVATEPORT: {{ $depServices.user_management.privatePort | quote }}
   # authorization服务
-  AUTHORIZATIONPRIVATEHOST: {{ .Values.depServices.authorization.privateHost | quote }}
-  AUTHORIZATIONPRIVATEPORT: {{ .Values.depServices.authorization.privatePort | quote }}
+  AUTHORIZATIONPRIVATEHOST: {{ $depServices.authorization.privateHost | quote }}
+  AUTHORIZATIONPRIVATEPORT: {{ $depServices.authorization.privatePort | quote }}
   dm_svc.conf: |
     TIME_ZON=(480)
     LANGUAGE=(cn)
@@ -63,5 +64,5 @@ data:
 
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-yaml
-  namespace: {{ .Values.namespace }}
+  name: {{ .Values.image.name }}-yaml
+  namespace: {{ .Release.Namespace }}

--- a/mf-model-manager/charts/templates/deployment.yaml
+++ b/mf-model-manager/charts/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $depServices := include "mfModelManager.depServices" . | fromYaml -}}
 {{- $configMapName := printf "%s-yaml" .Values.image.name -}}
 {{- $rdsConfVolume := printf "%s-rds-conf" .Values.image.name -}}
 apiVersion: apps/v1
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.image.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
+  replicas: {{ include "mfModelManager.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}
@@ -35,7 +35,7 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
-          image: "{{ include "mergedGlobalValues.image" . }}"
+          image: "{{ include "mfModelManager.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: model-factory

--- a/mf-model-manager/charts/templates/deployment.yaml
+++ b/mf-model-manager/charts/templates/deployment.yaml
@@ -1,10 +1,13 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $configMapName := printf "%s-yaml" .Values.image.name -}}
+{{- $rdsConfVolume := printf "%s-rds-conf" .Values.image.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}
@@ -32,7 +35,7 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
-          image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "mergedGlobalValues.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: model-factory
@@ -58,7 +61,7 @@ spec:
           volumeMounts:
             - name: host-time
               mountPath: /etc/localtime
-            - name: {{ .Release.Name }}-rds-conf
+            - name: {{ $rdsConfVolume }}
               mountPath: /tmp/rds_conf
           env:
             - name: DEVICE_CODE
@@ -66,236 +69,236 @@ spec:
             - name: RDSHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSHOST
             - name: RDSPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSPORT
             - name: RDSUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSUSER
             - name: RDSPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSPASS
             - name: DB_TYPE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: DB_TYPE
             - name: RDSDBNAME
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: RDSDBNAME
             - name: OPENSEARCH_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_HOST
             - name: OPENSEARCHWRITE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCHWRITE
             - name: OPENSEARCHREAD
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCHRED
             - name: OPENSEARCH_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_PORT
             - name: OPENSEARCH_USER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_USER
             - name: OPENSEARCH_PASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OPENSEARCH_PASS
             - name: REDISCLUSTERMODE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISCLUSTERMODE
             - name: REDISUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISUSER
             - name: REDISPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISPASS
-            {{- if ne .Values.depServices.redis.connectType "master-slave" }}
+            {{- if ne $depServices.redis.connectType "master-slave" }}
             - name: REDISHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISHOST
             - name: REDISPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISPORT
             {{- end }}
-            {{- if eq .Values.depServices.redis.connectType "sentinel" }}
+            {{- if eq $depServices.redis.connectType "sentinel" }}
             - name: SENTINELMASTER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: SENTINELMASTER
             - name: SENTINELUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: SENTINELUSER
             - name: SENTINELPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: SENTINELPASS
             {{- end }}
-            {{- if eq .Values.depServices.redis.connectType "master-slave" }}
+            {{- if eq $depServices.redis.connectType "master-slave" }}
             - name: REDISREADHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADHOST
             - name: REDISREADPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADPORT
             - name: REDISREADUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADUSER
             - name: REDISREADPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISREADPASS
             - name: REDISWRITEHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEHOST
             - name: REDISWRITEPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEPORT
             - name: REDISWRITEUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEUSER
             - name: REDISWRITEPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: REDISWRITEPASS
             {{- end }}
             - name: KAFKAHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAHOST
             - name: KAFKAPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAPORT
             - name: KAFKAUSER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAUSER
             - name: KAFKAPASS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: KAFKAPASS
             # 修复以下三个环境变量的配置
             - name: TEXTVECTORMAPPING
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: TEXTVECTORMAPPING
             - name: VLMVECTORMAPPING
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: VLMVECTORMAPPING
             - name: TEXTRERANKERMAPPING
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: TEXTRERANKERMAPPING
             - name: DM_SVC_PATH
               value: /tmp/rds_conf/
             - name: OAUTHPUBLICHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHPUBLICHOST
             - name: OAUTHPUBLICPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHPUBLICPORT
             - name: OAUTHADMINHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHADMINHOST
             - name: OAUTHADMINPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: OAUTHADMINPORT
             - name: USERMANAGEMENTPUBLICHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPUBLICHOST
             - name: USERMANAGEMENTPUBLICPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPUBLICPORT
             - name: USERMANAGEMENTPRIVATEHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPRIVATEHOST
             - name: USERMANAGEMENTPRIVATEPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: USERMANAGEMENTPRIVATEPORT
             - name: AUTHORIZATIONPRIVATEHOST
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: AUTHORIZATIONPRIVATEHOST
             - name: AUTHORIZATIONPRIVATEPORT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Release.Name }}-yaml
+                  name: {{ $configMapName }}
                   key: AUTHORIZATIONPRIVATEPORT
             # 可观测相关配置
             - name: LOG_ENABLED
@@ -332,9 +335,9 @@ spec:
         - name: host-time
           hostPath:
             path: /etc/localtime
-        - name: {{ .Release.Name }}-rds-conf
+        - name: {{ $rdsConfVolume }}
           configMap:
-            name: {{ .Release.Name }}-yaml
+            name: {{ $configMapName }}
             items:
             - key: dm_svc.conf
               path: dm_svc.conf

--- a/mf-model-manager/charts/templates/service.yaml
+++ b/mf-model-manager/charts/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.service.enableDualStack }}
   ipFamilyPolicy: PreferDualStack

--- a/studio-web/charts/studio-web/templates/configmap.yaml
+++ b/studio-web/charts/studio-web/templates/configmap.yaml
@@ -1,30 +1,32 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $accessAddress := include "mergedGlobalValues.accessAddress" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata: 
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
 data: 
   depServices.yaml: |
-    {{- toYaml .Values.depServices |  nindent 4 }}
+    {{- toYaml $depServices |  nindent 4 }}
   accessAddr.yaml: |
-    {{- toYaml .Values.accessAddress |  nindent 4 }}
+    {{- toYaml $accessAddress |  nindent 4 }}
 
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata: 
   name: {{ include "template.fullname" . }}-backend
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
 data: 
   APP_PORT: "8877"
-  APP_DB_HOST: {{ .Values.depServices.rds.host | quote }}
-  APP_DB_PORT: {{ .Values.depServices.rds.port | quote }}
-  APP_DB_NAME: {{ .Values.depServices.rds.database | quote }}
-  APP_DB_USER: {{ .Values.depServices.rds.user | quote }}
-  APP_DB_PASSWORD: {{ .Values.depServices.rds.password | quote }}
-  APP_DB_TYPE: {{ .Values.depServices.rds.type | upper | quote }}
-  APP_DB_SYSTEMID: {{ .Values.depServices.rds.system_id | default "" | quote }}
+  APP_DB_HOST: {{ $depServices.rds.host | quote }}
+  APP_DB_PORT: {{ $depServices.rds.port | quote }}
+  APP_DB_NAME: {{ $depServices.rds.database | quote }}
+  APP_DB_USER: {{ $depServices.rds.user | quote }}
+  APP_DB_PASSWORD: {{ $depServices.rds.password | quote }}
+  APP_DB_TYPE: {{ $depServices.rds.type | upper | quote }}
+  APP_DB_SYSTEMID: {{ $depServices.rds.system_id | default "" | quote }}

--- a/studio-web/charts/studio-web/templates/deployment.yaml
+++ b/studio-web/charts/studio-web/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- $replicaCount := include "mergedGlobalValues.replicaCount" . | int -}}
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: apps/v1
 {{- else -}}
@@ -6,7 +8,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
 spec:
@@ -15,9 +17,9 @@ spec:
   {{- toYaml . | nindent 4 }}
   {{- end }}
   {{ if not .Values.maxReplicaCount}}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ $replicaCount }}
   {{- else }}
-  replicas: {{ min .Values.replicaCount .Values.maxReplicaCount }}
+  replicas: {{ min $replicaCount .Values.maxReplicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -50,7 +52,7 @@ spec:
         - name: studio-web-service
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.studio_web_service.repository }}:{{ .Values.image.studio_web_service.tag }}"
+          image: "{{ $imageRegistry }}/{{ .Values.image.studio_web_service.repository }}:{{ .Values.image.studio_web_service.tag }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: 5
@@ -98,7 +100,7 @@ spec:
         - name: studio-web-static
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.studio_web_static.repository }}:{{ .Values.image.studio_web_static.tag }}"
+          image: "{{ $imageRegistry }}/{{ .Values.image.studio_web_static.repository }}:{{ .Values.image.studio_web_static.tag }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: 5
@@ -142,7 +144,7 @@ spec:
         - name: studio-web-backend
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.studio_web_backend.repository }}:{{ .Values.image.studio_web_backend.tag }}"
+          image: "{{ $imageRegistry }}/{{ .Values.image.studio_web_backend.repository }}:{{ .Values.image.studio_web_backend.tag }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/studio-web/charts/studio-web/templates/helpers.tpl
+++ b/studio-web/charts/studio-web/templates/helpers.tpl
@@ -2,24 +2,18 @@
 Expand the name of the chart.
 */}}
 {{- define "template.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "template.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Release.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -60,3 +54,44 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/* ========== Universal Global Values Merge Helpers ========== */}}
+
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $localDeps := .Values.depServices | default dict -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy $localDeps) $globalDeps) -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.accessAddress" -}}
+{{- $localAccess := .Values.accessAddress | default dict -}}
+{{- $globalAccess := (.Values.global | default dict).accessAddress | default dict -}}
+{{- toYaml (mergeOverwrite (deepCopy $localAccess) $globalAccess) -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- index (.Values.depServices | default dict) "class-443" "ingressClass" | default "nginx" -}}
+{{- end -}}
+{{- end -}}

--- a/studio-web/charts/studio-web/templates/ingress.yaml
+++ b/studio-web/charts/studio-web/templates/ingress.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -58,7 +58,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "template.fullname" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ index .Values.depServices "class-443" "ingressClass" }}
     {{- with .Values.ingress.annotations }}
@@ -90,4 +90,3 @@ spec:
         path: /studio
       
 {{- end }}
-

--- a/studio-web/charts/studio-web/templates/initdb-hook.yaml
+++ b/studio-web/charts/studio-web/templates/initdb-hook.yaml
@@ -1,21 +1,23 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata: 
   name: {{ include "template.fullname" . }}-backend-hook
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/hook: "post-install, post-upgrade"
     helm.sh/weight: "0"
 data: 
-  APP_DB_HOST: {{ .Values.depServices.rds.host | quote }}
-  APP_DB_PORT: {{ .Values.depServices.rds.port | quote }}
-  APP_DB_NAME: {{ .Values.depServices.rds.database | quote }}
-  APP_DB_USER: {{ .Values.depServices.rds.user | quote }}
-  APP_DB_PASSWORD: {{ .Values.depServices.rds.password | quote }}
-  APP_DB_TYPE: {{ .Values.depServices.rds.type | upper | quote }}
-  APP_DB_SYSTEMID: {{ .Values.depServices.rds.system_id | default "" | quote }}
+  APP_DB_HOST: {{ $depServices.rds.host | quote }}
+  APP_DB_PORT: {{ $depServices.rds.port | quote }}
+  APP_DB_NAME: {{ $depServices.rds.database | quote }}
+  APP_DB_USER: {{ $depServices.rds.user | quote }}
+  APP_DB_PASSWORD: {{ $depServices.rds.password | quote }}
+  APP_DB_TYPE: {{ $depServices.rds.type | upper | quote }}
+  APP_DB_SYSTEMID: {{ $depServices.rds.system_id | default "" | quote }}
 
 
 ---
@@ -24,7 +26,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "template.fullname" . }}-init-db
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/hook: "post-install, post-upgrade"
@@ -41,7 +43,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: studio-web-initdb
-          image: "{{ .Values.image.registry }}/{{ .Values.image.studio_web_backend.repository }}:{{ .Values.image.studio_web_backend.tag }}"
+          image: "{{ $imageRegistry }}/{{ .Values.image.studio_web_backend.repository }}:{{ .Values.image.studio_web_backend.tag }}"
           command: ["./initdb"]
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           envFrom:

--- a/studio-web/charts/studio-web/templates/service.yaml
+++ b/studio-web/charts/studio-web/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ $.Values.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   name: {{ include "template.fullname" $ }}-static
   labels:
     {{- include "template.labels" $ | nindent 4 }}
@@ -25,7 +25,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ $.Values.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   name: {{ include "template.fullname" $ }}-service
   labels:
     {{- include "template.labels" $ | nindent 4 }}

--- a/studio-web/charts/studio-web/templates/serviceaccount.yaml
+++ b/studio-web/charts/studio-web/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ include "template.serviceAccountName" . }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "template.serviceAccountName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,13 +23,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "template.serviceAccountName" . }}
-    namespace: {{ .Values.namespace | default .Release.Namespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "template.serviceAccountName" . }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - "*"


### PR DESCRIPTION
## Summary
- add umbrella-compatible global helper functions for the in-scope studio charts
- switch shared fullname logic to stable chart names for deploy-web, studio-web, and related workloads
- update model factory and business system charts to consume global image/replica values and avoid hook/resource-name collisions

## Test Plan
- helm template test ./deploy-web/charts/deploy-web
- helm template test ./studio-web/charts/studio-web
- helm template test ./frontend/applications/business-system/charts/business-system
- helm template test ./business-system-backend/helm/business-system-service
- helm template test ./frontend/applications/model-manager/charts/model-manager
- helm template test ./mf-model-manager/charts
- helm template test ./mf-model-api/charts